### PR TITLE
WFP-1648 remove convictionId from risk endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/controller/UnallocatedCasesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/controller/UnallocatedCasesController.kt
@@ -99,13 +99,13 @@ class UnallocatedCasesController(
     ]
   )
   @PreAuthorize("hasRole('ROLE_MANAGE_A_WORKFORCE_ALLOCATE')")
-  @GetMapping("/cases/unallocated/{crn}/convictions/{convictionId}/risks")
+  @GetMapping("/cases/unallocated/{crn}/convictions/{convictionNumber}/risks")
   fun getUnallocatedCaseRisks(
     @PathVariable(required = true) crn: String,
-    @PathVariable(required = true) convictionId: Long
+    @PathVariable(required = true) convictionNumber: Long
   ): ResponseEntity<UnallocatedCaseRisks> =
     ResponseEntity.ok(
-      getUnallocatedCaseService.getCaseRisks(crn, convictionId)
+      getUnallocatedCaseService.getCaseRisks(crn, convictionNumber)
         ?: throw EntityNotFoundException("Unallocated case risks Not Found for $crn")
     )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/domain/UnallocatedCaseRisks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/domain/UnallocatedCaseRisks.kt
@@ -20,7 +20,6 @@ data class UnallocatedCaseRisks @JsonCreator constructor(
   val roshRisk: RoshSummary?,
   val rsr: UnallocatedCaseRsr?,
   val ogrs: UnallocatedCaseOgrs?,
-  val convictionId: Long,
   @Schema(description = "Case Type")
   val caseType: CaseTypes,
   val convictionNumber: Int
@@ -54,7 +53,6 @@ data class UnallocatedCaseRisks @JsonCreator constructor(
             )
           }
         },
-        case.convictionId,
         case.caseType,
         case.convictionNumber
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetUnallocatedCaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetUnallocatedCaseService.kt
@@ -139,8 +139,8 @@ class GetUnallocatedCaseService(
     }?.takeUnless { orderManager -> orderManager.isUnallocated }
       ?.let { orderManager -> UnallocatedCaseConvictionPractitioner(orderManager.name, orderManager.staffGrade) }
 
-  fun getCaseRisks(crn: String, convictionId: Long): UnallocatedCaseRisks? =
-    findUnallocatedCaseByConvictionIdOrConvictionNumber(crn, convictionId)?.let {
+  fun getCaseRisks(crn: String, convictionNumber: Long): UnallocatedCaseRisks? =
+    findUnallocatedCaseByConvictionIdOrConvictionNumber(crn, convictionNumber)?.let {
       val registrations = communityApiClient.getAllRegistrations(crn)
         .map { registrations ->
           registrations.registrations?.groupBy { registration -> registration.active } ?: emptyMap()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetCaseRisksByCrnTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetCaseRisksByCrnTest.kt
@@ -8,14 +8,14 @@ class GetCaseRisksByCrnTest : IntegrationTestBase() {
   @Test
   fun `can get case risks by crn and convictionId`() {
     val crn = "J678910"
-    val convictionId = 123456789L
+    val convictionNumber = 1
     insertCases()
     getRegistrationsFromDelius(crn)
     getRoshForCrn(crn)
     getRiskPredictorsForCrn(crn)
     getOgrsForCrn(crn)
     webTestClient.get()
-      .uri("/cases/unallocated/$crn/convictions/$convictionId/risks")
+      .uri("/cases/unallocated/$crn/convictions/$convictionNumber/risks")
       .headers { it.authToken(roles = listOf("ROLE_MANAGE_A_WORKFORCE_ALLOCATE")) }
       .exchange()
       .expectStatus()
@@ -65,8 +65,6 @@ class GetCaseRisksByCrnTest : IntegrationTestBase() {
       .isEqualTo("2018-11-17")
       .jsonPath("$.ogrs.score")
       .isEqualTo(85)
-      .jsonPath("$.convictionId")
-      .isEqualTo(convictionId)
       .jsonPath("$.caseType")
       .isEqualTo("CUSTODY")
       .jsonPath("$.convictionNumber")
@@ -76,14 +74,14 @@ class GetCaseRisksByCrnTest : IntegrationTestBase() {
   @Test
   fun `get case risks with no registrations`() {
     val crn = "J678910"
-    val convictionId = 123456789L
+    val convictionNumber = 1
     insertCases()
     noRegistrationsFromDelius(crn)
     getRoshForCrn(crn)
     getRiskPredictorsForCrn(crn)
     getOgrsForCrn(crn)
     webTestClient.get()
-      .uri("/cases/unallocated/$crn/convictions/$convictionId/risks")
+      .uri("/cases/unallocated/$crn/convictions/$convictionNumber/risks")
       .headers { it.authToken(roles = listOf("ROLE_MANAGE_A_WORKFORCE_ALLOCATE")) }
       .exchange()
       .expectStatus()
@@ -96,35 +94,16 @@ class GetCaseRisksByCrnTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `get case risks by crn and convictionNumber`() {
-    val crn = "J678910"
-    insertCases()
-    noRegistrationsFromDelius(crn)
-    getRoshForCrn(crn)
-    getRiskPredictorsForCrn(crn)
-    getOgrsForCrn(crn)
-    webTestClient.get()
-      .uri("/cases/unallocated/$crn/convictions/1/risks")
-      .headers { it.authToken(roles = listOf("ROLE_MANAGE_A_WORKFORCE_ALLOCATE")) }
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .jsonPath("$.convictionNumber")
-      .isEqualTo(1)
-  }
-
-  @Test
   fun `get case risks with no ROSH summary`() {
     val crn = "J678910"
-    val convictionId = 123456789L
+    val convictionNumber = 1
     insertCases()
     noRegistrationsFromDelius(crn)
     getRoshNotFoundForCrn(crn)
     getRiskPredictorsForCrn(crn)
     getOgrsForCrn(crn)
     webTestClient.get()
-      .uri("/cases/unallocated/$crn/convictions/$convictionId/risks")
+      .uri("/cases/unallocated/$crn/convictions/$convictionNumber/risks")
       .headers { it.authToken(roles = listOf("ROLE_MANAGE_A_WORKFORCE_ALLOCATE")) }
       .exchange()
       .expectStatus()
@@ -137,14 +116,14 @@ class GetCaseRisksByCrnTest : IntegrationTestBase() {
   @Test
   fun `get case risks with no ogrs`() {
     val crn = "J678910"
-    val convictionId = 123456789L
+    val convictionNumber = 1
     insertCases()
     getRoshForCrn(crn)
     noRegistrationsFromDelius(crn)
     notFoundOgrsForCrn(crn)
     getRiskPredictorsForCrn(crn)
     webTestClient.get()
-      .uri("/cases/unallocated/$crn/convictions/$convictionId/risks")
+      .uri("/cases/unallocated/$crn/convictions/$convictionNumber/risks")
       .headers { it.authToken(roles = listOf("ROLE_MANAGE_A_WORKFORCE_ALLOCATE")) }
       .exchange()
       .expectStatus()
@@ -157,14 +136,14 @@ class GetCaseRisksByCrnTest : IntegrationTestBase() {
   @Test
   fun `get case risks with no ROSH level`() {
     val crn = "J678910"
-    val convictionId = 123456789L
+    val convictionNumber = 1
     insertCases()
     noRegistrationsFromDelius(crn)
     getRoshNoLevelForCrn(crn)
     getRiskPredictorsForCrn(crn)
     getOgrsForCrn(crn)
     webTestClient.get()
-      .uri("/cases/unallocated/$crn/convictions/$convictionId/risks")
+      .uri("/cases/unallocated/$crn/convictions/$convictionNumber/risks")
       .headers { it.authToken(roles = listOf("ROLE_MANAGE_A_WORKFORCE_ALLOCATE")) }
       .exchange()
       .expectStatus()
@@ -177,13 +156,13 @@ class GetCaseRisksByCrnTest : IntegrationTestBase() {
   @Test
   fun `can get case risks when no registrations are returned`() {
     val crn = "J678910"
-    val convictionId = 123456789L
+    val convictionNumber = 1
     insertCases()
     noRegistrationsFromDelius(crn)
     getRoshForCrn(crn)
     getOgrsForCrn(crn)
     webTestClient.get()
-      .uri("/cases/unallocated/$crn/convictions/$convictionId/risks")
+      .uri("/cases/unallocated/$crn/convictions/$convictionNumber/risks")
       .headers { it.authToken(roles = listOf("ROLE_MANAGE_A_WORKFORCE_ALLOCATE")) }
       .exchange()
       .expectStatus()


### PR DESCRIPTION
https://github.com/ministryofjustice/manage-a-workforce-ui/blob/main/server/models/Risk.ts
To be fair that model is missing some properties on the response which are relied upon in the njk template - ogrs and rsr - but that is the beauty of TypeScript of course