### PR TITLE
WFP-1720: Update AppInsights options for v3

### DIFF
--- a/applicationinsights.dev.json
+++ b/applicationinsights.dev.json
@@ -6,12 +6,18 @@
     "service.version": "${BUILD_NUMBER}"
   },
   "instrumentation": {
+    "jms": {
+      "enabled": false
+    },
     "logging": {
       "level": "DEBUG"
     }
   },
   "selfDiagnostics": {
     "destination": "console"
+  },
+  "sampling": {
+    "percentage": 100
   },
   "preview": {
     "sampling": {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/CalculationEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/CalculationEventListener.kt
@@ -27,9 +27,6 @@ class CalculationEventListener(
     eventData.occurredAt.let {
       val timeToDeliverMs = Duration.between(it, LocalDateTime.now())
       log.info("Delivered TierCalculationEvent in (${timeToDeliverMs.seconds}): Crn ${crnFrom(eventData)}")
-      if (timeToDeliverMs.seconds > 1) {
-        log.warn("Delayed TierCalculationEvent delivery (${timeToDeliverMs.seconds}): Crn ${crnFrom(eventData)}")
-      }
     }
     return eventData
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/OffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/OffenderEventListener.kt
@@ -37,9 +37,6 @@ class OffenderEventListener(
     eventData.eventDatetime.let {
       val timeToDeliverMs = Duration.between(it, ZonedDateTime.now())
       log.info("Delivered OffenderEvent in (${timeToDeliverMs.seconds}): Crn ${eventData.crn}")
-      if (timeToDeliverMs.seconds > 1) {
-        log.warn("Delayed OffenderEvent delivery (${timeToDeliverMs.seconds}): Crn ${eventData.crn}")
-      }
     }
     return eventData.crn
   }


### PR DESCRIPTION
Updates to event logging based on information in https://learn.microsoft.com/en-us/azure/azure-monitor/app/java-standalone-config:

 - We are trying to turn JMS logging off as it does not contain enough information
 - We are increasing sampling to 100% (i.e. all messages) to see if that proves we previously lost messages