### PR TITLE
README for local deployment and new local profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,58 @@ https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-allocations
 * Docker
 * OAuth token
 
-### How to run locally
+### How to run locally against dev environment
 
-Execute the following commands:
+#### Running hmpps-allocations service locally
+* Local development is normally done by working TDD and using unit/integration tests to drive development (and validate everything works) - see the `How to run the tests locally` section below for how to do this
+* There are occasions where you might want to run locally against the dev environment so that you can check everything is working with real(ish) data on the DEV environment
+* The following steps will allow you to do this and integrate with:
+    * DEV Allocations DB (AWS RDS Database)
+    * DEV hmpps-tier service
+    * DEV assessment service
+    * DEV assess-risks-needs service
+    * DEV workforce-allocations-to-delius service
+    * DEV community service
+* The host urls for all the services listed above are configured in `application-local.yml`
+* All secrets for authentication with these service and connection to the RDS database are passed as VM options (and not kept in code for security reasons) - see later section
 
+#### Prep for running service - Connect to DEV RDS DB
+* To connect to the DEV database we will need to port forward it
+* Here is the wiki on how to do this [Access the DEV RDS Database](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/rds-external-access.html#accessing-your-rds-database)
+
+#### Run localstack docker service locally
+* we can run `localstack` locally as a docker container so that we do not need to integrate with the messaging infrastructure in AWS (the application is reliant on this for processing events)
+* to run `localstack` run this from this repo's root directory: 
+```
+docker-compose up -d localstack
+```
+* with the above command, you will have noticed that we are specifically running the `localstack` container only. If we were to run the usual `docker-compose up -d` command then we would run the `postgres` container also which would port clash with the port forward we are running for the DEV DB
+
+#### Run service in Intellij
+* Right-click and Run `uk.gov.justice.digital.hmpps.hmppsallocations.HmppsAllocations`
+* This will fail initially but will have created a `Run Configuration` called `HmppsAllocations` in the configuration dropdown next to the `Run` and `Debug` buttons
+* Click on the `HmppsAllocations` configuration > `Edit Configuration`
+* In the `VM Options` box paste the following:
+```
+-Dspring.profiles.active=local
+-Doauth.client.id=<retrieve_k8s_secret__AUTH_API_CLIENT_ID> 
+-Doauth.client.secret=<retrieve_k8s_secret__AUTH_API_CLIENT_SECRET> 
+-Ddatabase.name=<retrieve_k8s_secret__database_name> 
+-Ddatabase.username=<retrieve_k8s_secret__database_username> 
+-Ddatabase.password=<retrieve_k8s_secret__database_password>
+```
+* The placeholder values in the above properties need to be swapped out for the real secrets in your configuration
+* These secrets are stored in `Kubernetes` and can be accessed in the `hmpps-allocations` and `rds-allocation-instance-output` secrets
+* Here is a guide for [connecting to the Kubernetes Cluster](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#connecting-to-the-cloud-platform-39-s-kubernetes-cluster) to access the secrets
+* Once the secrets are finalised save the configuration with the following:
+  * Click `Apply`
+  * Click `OK`
+* You should now be able to `Run` and `Debug` the application using this configuration by hitting the `Run` and `Debug` buttons next to the configuration
+
+#### Run service in Terminal
+Execute the following command:
 ```shell
-docker-compose up -d
-./gradlew bootRun
+./gradlew bootRun -Dspring.profiles.active=local -Doauth.client.id=<retrieve_k8s_secret__AUTH_API_CLIENT_ID> -Doauth.client.secret=<retrieve_k8s_secret__AUTH_API_CLIENT_SECRET> -Ddatabase.name=<retrieve_k8s_secret__database_name> -Ddatabase.username=<retrieve_k8s_secret__database_username> -Ddatabase.password=<retrieve_k8s_secret__database_password>
 ```
 
 ### How to run the tests locally

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,44 @@
+hmpps.sqs:
+  provider: localstack
+  queues:
+    tiercalculationqueue:
+      queueName: hmpps_tier_event_queue
+      dlqName: hmpps_tier_event_dlq
+      subscribeTopicId: hmppsdomaintopic
+      subscribeFilter: '{"eventType":[ "TIER_CALCULATION_COMPLETE"] }'
+      dlqMaxReceiveCount: 1
+    hmppsoffenderqueue:
+      queueName: hmpps_offender_event_queue
+      dlqName: hmpps_offender_event_dlq
+      subscribeTopicId: hmppsoffendertopic
+      subscribeFilter: '{"eventType":[ "CONVICTION_CHANGED", "OFFENDER_MANAGER_CHANGED"] }'
+      dlqMaxReceiveCount: 1
+  topics:
+    hmppsdomaintopic:
+      arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
+    hmppsoffendertopic:
+      arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
+
+hmpps-tier:
+  endpoint:
+    url: https://hmpps-tier-dev.hmpps.service.justice.gov.uk
+
+assessment:
+  endpoint:
+    url: https://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk
+
+assess-risks-needs:
+  endpoint:
+    url: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
+
+workforce-allocations-to-delius:
+  endpoint:
+    url: https://workforce-allocations-to-delius-dev.hmpps.service.justice.gov.uk
+
+community:
+  endpoint:
+    url: https://community-api-secure.test.delius.probation.hmpps.dsd.io/secure
+
+oauth:
+  endpoint:
+    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth


### PR DESCRIPTION
PR to add new local profile for running the application locally against dev (fully documented in `README.md`):

<img width="1600" alt="postman_hitting_API_for_locally_deployed_service" src="https://github.com/ministryofjustice/hmpps-allocations/assets/148795810/ba64b99c-831f-476a-940a-96a4877175fb">
