### PR TITLE
:sparkles: WFP-2259: added staff name data to initial appointment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
@@ -152,7 +152,7 @@ data class DeliusCaseDetail(
 data class Event(val number: String)
 
 data class ProbationStatus(val description: String)
-data class InitialAppointment(val date: LocalDate?, val staff: Staff?)
+data class InitialAppointment(val date: LocalDate, val staff: Staff)
 
 data class Staff @JsonCreator constructor(
   val name: Name,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
@@ -152,14 +152,14 @@ data class DeliusCaseDetail(
 data class Event(val number: String)
 
 data class ProbationStatus(val description: String)
-data class InitialAppointment(val date: LocalDate?, val staff: Staff)
+data class InitialAppointment(val date: LocalDate, val staff: Staff)
 
 data class Staff @JsonCreator constructor(
   val name: Name,
 )
 data class DeliusCaseDetails(val cases: List<DeliusCaseDetail>)
 
-data class Name(val forename: String?, val middleName: String?, val surname: String?) {
+data class Name(val forename: String, val middleName: String?, val surname: String) {
   fun getCombinedName() = "$forename ${middleName?.takeUnless { it.isBlank() }?.let { "$middleName " } ?: ""}$surname"
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
@@ -155,7 +155,7 @@ data class ProbationStatus(val description: String)
 data class InitialAppointment(val date: LocalDate?, val staff: Staff?)
 
 data class Staff @JsonCreator constructor(
-  val name: Name?
+  val name: Name?,
 )
 data class DeliusCaseDetails(val cases: List<DeliusCaseDetail>)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
@@ -142,8 +142,8 @@ data class DeliusCaseDetail(
   val crn: String,
   val name: Name,
   val sentence: Sentence,
-  val event: Event,
   val initialAppointment: InitialAppointment?,
+  val event: Event,
   val probationStatus: ProbationStatus,
   val communityPersonManager: CommunityPersonManager?,
   val type: String,
@@ -152,9 +152,14 @@ data class DeliusCaseDetail(
 data class Event(val number: String)
 
 data class ProbationStatus(val description: String)
-data class InitialAppointment(val date: LocalDate?)
+data class InitialAppointment(val date: LocalDate?, val staff: Staff?)
+
+data class Staff @JsonCreator constructor(
+  val name: Name?
+)
 data class DeliusCaseDetails(val cases: List<DeliusCaseDetail>)
-data class Name(val forename: String, val middleName: String?, val surname: String) {
+
+data class Name(val forename: String?, val middleName: String?, val surname: String?) {
   fun getCombinedName() = "$forename ${middleName?.takeUnless { it.isBlank() }?.let { "$middleName " } ?: ""}$surname"
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
@@ -152,10 +152,10 @@ data class DeliusCaseDetail(
 data class Event(val number: String)
 
 data class ProbationStatus(val description: String)
-data class InitialAppointment(val date: LocalDate?, val staff: Staff?)
+data class InitialAppointment(val date: LocalDate?, val staff: Staff)
 
 data class Staff @JsonCreator constructor(
-  val name: Name?,
+  val name: Name,
 )
 data class DeliusCaseDetails(val cases: List<DeliusCaseDetail>)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
@@ -152,7 +152,7 @@ data class DeliusCaseDetail(
 data class Event(val number: String)
 
 data class ProbationStatus(val description: String)
-data class InitialAppointment(val date: LocalDate, val staff: Staff)
+data class InitialAppointment(val date: LocalDate?, val staff: Staff?)
 
 data class Staff @JsonCreator constructor(
   val name: Name,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/domain/UnallocatedCase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/domain/UnallocatedCase.kt
@@ -18,9 +18,8 @@ data class UnallocatedCase @JsonCreator constructor(
   @Schema(description = "Sentence Date", example = "2020-01-16")
   @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
   val sentenceDate: LocalDate,
-  @Schema(description = "Initial Appointment Date", example = "2020-03-21")
-  @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
-  val initialAppointment: LocalDate?,
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  val initialAppointment: InitialAppointmentDetails?,
   @Schema(description = "Probation Status", example = "Currently managed")
   val status: String,
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -38,7 +37,9 @@ data class UnallocatedCase @JsonCreator constructor(
         deliusCaseDetail.crn,
         case.tier,
         deliusCaseDetail.sentence.date,
-        deliusCaseDetail.initialAppointment?.date,
+        InitialAppointmentDetails.from(
+          deliusCaseDetail.initialAppointment,
+        ),
         deliusCaseDetail.probationStatus.description,
         OffenderManagerDetails.from(
           deliusCaseDetail.communityPersonManager,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/domain/UnallocatedCaseDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/domain/UnallocatedCaseDetails.kt
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.CommunityPersonManager
+import uk.gov.justice.digital.hmpps.hmppsallocations.client.InitialAppointment
+import uk.gov.justice.digital.hmpps.hmppsallocations.client.Staff
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.dto.CaseViewDocument
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.dto.DeliusCaseView
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.dto.MainAddress
@@ -119,6 +121,22 @@ data class OffenderManagerDetails @JsonCreator constructor(
         return grade
       }
       return null
+    }
+  }
+}
+
+data class InitialAppointmentDetails @JsonCreator constructor(
+  @Schema(description = "Initial appointment Date", example = "2020-01-16")
+  val date: LocalDate?,
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  val staff: Staff?,
+) {
+  companion object {
+    fun from(initialAppointment: InitialAppointment?): InitialAppointmentDetails {
+      return InitialAppointmentDetails(
+        initialAppointment?.date,
+        initialAppointment?.staff,
+      )
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/domain/CaseDetailsIntegration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/domain/CaseDetailsIntegration.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsallocations.integration.domain
 
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.CommunityPersonManager
-import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.hmppsallocations.client.InitialAppointment
 
 data class CaseDetailsIntegration(
   val crn: String,
   val eventNumber: String,
-  val initialAppointment: LocalDate?,
+  val initialAppointment: InitialAppointment?,
   val probationStatusDescription: String,
   val communityPersonManager: CommunityPersonManager?,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
@@ -107,7 +107,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
       CaseDetailsIntegration(
         "J680660",
         "4",
-        InitialAppointment(LocalDate.now(), null),
+        InitialAppointment(LocalDate.now(), Staff(Name("Beverley", "Rose", "Smith"))),
         "Previously managed",
         null,
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
@@ -13,7 +13,9 @@ import org.springframework.core.io.ClassPathResource
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.CommunityPersonManager
+import uk.gov.justice.digital.hmpps.hmppsallocations.client.InitialAppointment
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.Name
+import uk.gov.justice.digital.hmpps.hmppsallocations.client.Staff
 import uk.gov.justice.digital.hmpps.hmppsallocations.integration.domain.CaseDetailsIntegration
 import uk.gov.justice.digital.hmpps.hmppsallocations.integration.domain.CaseViewAddressIntegration
 import uk.gov.justice.digital.hmpps.hmppsallocations.integration.mockserver.WorkforceAllocationsToDeliusApiExtension.Companion.workforceAllocationsToDelius
@@ -84,7 +86,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
       CaseDetailsIntegration(
         "J678910",
         "1",
-        LocalDate.of(2022, 10, 11),
+        InitialAppointment(LocalDate.of(2022, 10, 11), Staff(Name("Beverley", "Rose", "Smith"))),
         "Currently managed",
         CommunityPersonManager(Name("Beverley", null, "Smith"), "SPO"),
       ),
@@ -98,14 +100,14 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
       CaseDetailsIntegration(
         "X4565764",
         "3",
-        LocalDate.now(),
+        InitialAppointment(LocalDate.now(), Staff(Name("Beverley", null, "Smith"))),
         "New to probation",
         CommunityPersonManager(Name("Beverley", null, "Smith"), "SPO"),
       ),
       CaseDetailsIntegration(
         "J680660",
         "4",
-        LocalDate.now(),
+        InitialAppointment(LocalDate.now(), null),
         "Previously managed",
         null,
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/responses/workforceallocationstodelius/FullDeliusCaseDetailsResponse.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/responses/workforceallocationstodelius/FullDeliusCaseDetailsResponse.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsallocations.integration.responses.workforceallocationstodelius
 
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.CommunityPersonManager
+import uk.gov.justice.digital.hmpps.hmppsallocations.client.InitialAppointment
 import uk.gov.justice.digital.hmpps.hmppsallocations.integration.domain.CaseDetailsIntegration
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 fun fullDeliusCaseDetailsResponse(vararg caseDetailsIntegrations: CaseDetailsIntegration) = """
@@ -48,12 +48,22 @@ private fun deliusCaseDetail(caseDetailsIntegration: CaseDetailsIntegration) = "
   communityPersonManager(caseDetailsIntegration.communityPersonManager) +
   "}".trimIndent()
 
-private fun initialAppointment(initialAppointment: LocalDate?): String {
+private fun initialAppointment(initialAppointment: InitialAppointment?): String {
   return initialAppointment?.let {
     """
       ,"initialAppointment": {
-        "date": ${initialAppointment.format(DateTimeFormatter.ofPattern("\"yyyy-MM-dd\""))}
-      }
+        "date": ${initialAppointment.date?.format(DateTimeFormatter.ofPattern("\"yyyy-MM-dd\""))},
+        "staff": {
+          "code": "string",
+          "name": {
+            "forename": "${initialAppointment.staff?.name?.forename}",
+            "middleName": "${initialAppointment.staff?.name?.middleName}",
+            "surname": "${initialAppointment.staff?.name?.surname}"
+          },
+          "email": "string",
+          "grade": "string"
+        }
+        }
     """.trimIndent()
   } ?: ""
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetUnallocatedCasesByTeamTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetUnallocatedCasesByTeamTests.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsallocations.integration.unallocatedcases
 
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppsallocations.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsallocations.integration.mockserver.WorkforceAllocationsToDeliusApiExtension.Companion.workforceAllocationsToDelius
@@ -28,12 +29,21 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
       .expectStatus()
       .isOk
       .expectBody()
+      .consumeWith(System.out::println)
       .jsonPath("$.length()")
       .isEqualTo(4)
       .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].sentenceDate")
       .isEqualTo(firstSentenceDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
-      .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].initialAppointment")
+      .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].initialAppointment.date")
       .isEqualTo(initialAppointment.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+      .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].initialAppointment.staff.name.forename")
+      .isEqualTo("Beverley")
+      .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].initialAppointment.staff.name.middleName")
+      .isEqualTo("Rose")
+      .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].initialAppointment.staff.name.surname")
+      .isEqualTo("Smith")
+      .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].initialAppointment.staff.name.combinedName")
+      .isEqualTo("Beverley Rose Smith")
       .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].name")
       .isEqualTo("Dylan Adam Armstrong")
       .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].crn")
@@ -52,8 +62,6 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
       .isEqualTo("CUSTODY")
       .jsonPath("$.[?(@.convictionNumber == 2 && @.crn == 'J680648')].status")
       .isEqualTo("Previously managed")
-      .jsonPath("$.[?(@.convictionNumber == 2 && @.crn == 'J680648')].initialAppointment")
-      .isEqualTo(null)
       .jsonPath("$.[?(@.convictionNumber == 2 && @.crn == 'J680648')].offenderManager.forenames")
       .isEqualTo("Janie")
       .jsonPath("$.[?(@.convictionNumber == 2 && @.crn == 'J680648')].offenderManager.surname")
@@ -143,5 +151,9 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
       .expectBody()
       .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].sentenceLength")
       .isEqualTo("5 Weeks")
+  }
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetUnallocatedCasesByTeamTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetUnallocatedCasesByTeamTests.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsallocations.integration.unallocatedcases
 
 import org.junit.jupiter.api.Test
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppsallocations.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsallocations.integration.mockserver.WorkforceAllocationsToDeliusApiExtension.Companion.workforceAllocationsToDelius
@@ -29,7 +28,6 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
       .expectStatus()
       .isOk
       .expectBody()
-      .consumeWith(System.out::println)
       .jsonPath("$.length()")
       .isEqualTo(4)
       .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].sentenceDate")
@@ -151,9 +149,5 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
       .expectBody()
       .jsonPath("$.[?(@.convictionNumber == 1 && @.crn == 'J678910')].sentenceLength")
       .isEqualTo("5 Weeks")
-  }
-
-  companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
   }
 }


### PR DESCRIPTION
This PR adds the staff name data to an initial appointment JSON object along with the date at the hmpps-allocations API `/team/{teamCode}/cases/unallocated`. 
I have used the `Name` type we currently have to include the `combinedName` JSON property alongside `forename`, `middleName` and `surname` to be in line with our other endpoints. I've created a staff object incase we want to add any other staff data in the future.