### PR TITLE
Unallocated cases APIi optimisation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/jpa/repository/UnallocatedCasesRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/jpa/repository/UnallocatedCasesRepository.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.hmppsallocations.jpa.projection.CaseCountByT
 interface UnallocatedCasesRepository : CrudRepository<UnallocatedCaseEntity, Long> {
   fun existsByCrn(crn: String): Boolean
 
-  fun existsByCrnAndConvictionNumber(crn: String, convictionNumber: Int): Boolean
   fun findByCrn(crn: String): List<UnallocatedCaseEntity>
 
   fun findCaseByCrnAndConvictionNumber(crn: String, convictionNumber: Int): UnallocatedCaseEntity?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetUnallocatedCaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetUnallocatedCaseService.kt
@@ -112,7 +112,7 @@ class GetUnallocatedCaseService(
   suspend fun getAllByTeam(teamCode: String): List<UnallocatedCase> {
     val unallocatedCasesFromRepo = unallocatedCasesRepository.findByTeamCode(teamCode)
     val unallocatedCasesUserAccess = workforceAllocationsToDeliusApiClient.getUserAccess(
-      crns = unallocatedCasesFromRepo.map { it.crn }
+      crns = unallocatedCasesFromRepo.map { it.crn },
     ).access
 
     val unallocatedCases = unallocatedCasesFromRepo.filter { uc ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/IntegrationTestBase.kt
@@ -134,7 +134,7 @@ abstract class IntegrationTestBase {
           convictionNumber = 1,
         ),
         laoCase1,
-        laoCase2
+        laoCase2,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/IntegrationTestBase.kt
@@ -55,6 +55,26 @@ abstract class IntegrationTestBase {
     convictionNumber = 4,
   )
 
+  val laoCase1 = UnallocatedCaseEntity(
+    null,
+    "Joe Bloggs",
+    "XXXXXXX",
+    "C2",
+    providerCode = "",
+    teamCode = "TEAM1",
+    convictionNumber = 1,
+  )
+
+  val laoCase2 = UnallocatedCaseEntity(
+    null,
+    "Joe Bloggs",
+    "ZZZZZZZ",
+    "C2",
+    providerCode = "",
+    teamCode = "TEAM1",
+    convictionNumber = 1,
+  )
+
   fun insertCases() {
     repository.saveAll(
       listOf(
@@ -113,6 +133,8 @@ abstract class IntegrationTestBase {
           teamCode = "TEAM1",
           convictionNumber = 1,
         ),
+        laoCase1,
+        laoCase2
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
@@ -93,7 +93,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
       .withMethod("POST")
       .withBody(
         jacksonObjectMapper()
-          .writeValueAsString(caseAccessList.map { it.first })
+          .writeValueAsString(caseAccessList.map { it.first }),
       )
 
     workforceAllocationsToDelius.`when`(request, Times.exactly(1)).respond(
@@ -146,7 +146,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
         probationStatusDescription = "Previously managed",
         communityPersonManager = null,
       ),
-      *extraCaseDetailsIntegrations
+      *extraCaseDetailsIntegrations,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsallocations.integration.mockserver
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
@@ -83,6 +84,23 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
     workforceAllocationsToDelius.`when`(initialAppointmentRequest, Times.exactly(1)).respond(
       HttpResponse.response().withContentType(MediaType.APPLICATION_JSON)
         .withBody(fullDeliusCaseDetailsResponse(*caseDetailsIntegrations)),
+    )
+  }
+
+  fun userHasAccessToAllCases(caseAccessList: List<Triple<String, Boolean, Boolean>>) {
+    val request = HttpRequest.request()
+      .withPath("/users/limited-access")
+      .withMethod("POST")
+      .withBody(
+        jacksonObjectMapper()
+          .writeValueAsString(caseAccessList.map { it.first })
+      )
+
+    workforceAllocationsToDelius.`when`(request, Times.exactly(1)).respond(
+      HttpResponse.response()
+        .withStatusCode(200)
+        .withContentType(MediaType.APPLICATION_JSON)
+        .withBody(deliusUserAccessResponse(caseAccessList)),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
@@ -146,6 +146,14 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
         probationStatusDescription = "Previously managed",
         communityPersonManager = null,
       ),
+      CaseDetailsIntegration(
+        crn = "ZZZZZZZ",
+        eventNumber = "1",
+        initialAppointment = InitialAppointment(LocalDate.now(), Staff(Name("Beverley", "Rose", "Smith"))),
+        probationStatus = "NEW_TO_PROBATION",
+        probationStatusDescription = "New to probation",
+        communityPersonManager = null,
+      ),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
@@ -118,7 +118,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
     )
   }
 
-  fun setupTeam1CaseDetails() {
+  fun setupTeam1CaseDetails(vararg extraCaseDetailsIntegrations: CaseDetailsIntegration) {
     deliusCaseDetailsResponse(
       currentMangedByTeam1CaseDetails,
       currentMangedByTeam2CaseDetails,
@@ -146,14 +146,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
         probationStatusDescription = "Previously managed",
         communityPersonManager = null,
       ),
-      CaseDetailsIntegration(
-        crn = "ZZZZZZZ",
-        eventNumber = "1",
-        initialAppointment = InitialAppointment(LocalDate.now(), Staff(Name("Beverley", "Rose", "Smith"))),
-        probationStatus = "NEW_TO_PROBATION",
-        probationStatusDescription = "New to probation",
-        communityPersonManager = null,
-      ),
+      *extraCaseDetailsIntegrations
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/responses/communityapi/DeliusUserAccessResponse.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/responses/communityapi/DeliusUserAccessResponse.kt
@@ -11,9 +11,9 @@ fun deliusUserAccessResponse(crn: String, restricted: Boolean, excluded: Boolean
 fun deliusUserAccessResponse(caseAccessList: List<Triple<String, Boolean, Boolean>>): String =
   """ {
     "access": [
-      ${caseAccessList.joinToString { 
-        deliusCaseAccess(it.first, it.second, it.third)
-      }}
+      ${caseAccessList.joinToString {
+    deliusCaseAccess(it.first, it.second, it.third)
+  }}
     ]
   }"""
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/responses/communityapi/DeliusUserAccessResponse.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/responses/communityapi/DeliusUserAccessResponse.kt
@@ -3,11 +3,26 @@ package uk.gov.justice.digital.hmpps.hmppsallocations.integration.responses.comm
 fun deliusUserAccessResponse(crn: String, restricted: Boolean, excluded: Boolean) = """
   {
     "access": [
-      {
-        "crn": "$crn",
-        "userRestricted": $restricted,
-        "userExcluded": $excluded
-      }
+      ${deliusCaseAccess(crn, restricted, excluded)}
     ]
   }
 """.trimIndent()
+
+fun deliusUserAccessResponse(caseAccessList: List<Triple<String, Boolean, Boolean>>): String =
+  """ {
+    "access": [
+      ${caseAccessList.joinToString { 
+        deliusCaseAccess(it.first, it.second, it.third)
+      }}
+    ]
+  }"""
+
+fun deliusCaseAccess(crn: String, restricted: Boolean, excluded: Boolean): String {
+  return """
+  {
+    "crn": "$crn",
+    "userRestricted": $restricted,
+    "userExcluded": $excluded
+  }
+  """
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/team/GetCaseCountByTeam.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/team/GetCaseCountByTeam.kt
@@ -20,7 +20,7 @@ class GetCaseCountByTeam : IntegrationTestBase() {
       .jsonPath("$[0].teamCode")
       .isEqualTo(teamCode)
       .jsonPath("$.[0].caseCount")
-      .isEqualTo(5)
+      .isEqualTo(7)
   }
 
   @Test
@@ -36,7 +36,7 @@ class GetCaseCountByTeam : IntegrationTestBase() {
       .isOk
       .expectBody()
       .jsonPath("$.[?(@.teamCode=='$firstTeamCode')].caseCount")
-      .isEqualTo(5)
+      .isEqualTo(7)
       .jsonPath("$.[?(@.teamCode=='$secondTeamCode')].caseCount")
       .isEqualTo(1)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetUnallocatedCasesByTeamTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetUnallocatedCasesByTeamTests.kt
@@ -18,7 +18,9 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
       Triple("J680648", false, false),
       Triple("X4565764", false, false),
       Triple("J680660", false, false),
-      Triple("X6666222", false, false)
+      Triple("X6666222", false, false),
+      Triple("XXXXXXX", true, false),
+      Triple("ZZZZZZZ", false, true)
     ))
     insertCases()
     val initialAppointment = LocalDate.of(2022, 10, 11)
@@ -151,7 +153,9 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
       Triple("J680648", false, false),
       Triple("X4565764", false, false),
       Triple("J680660", false, false),
-      Triple("X6666222", false, false)
+      Triple("X6666222", false, false),
+      Triple("XXXXXXX", true, false),
+      Triple("ZZZZZZZ", false, true)
     ))
     insertCases()
 
@@ -210,7 +214,9 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
       Triple("J680648", false, false),
       Triple("X4565764", false, false),
       Triple("J680660", false, false),
-      Triple("X6666222", false, false)
+      Triple("X6666222", false, false),
+      Triple("XXXXXXX", true, false),
+      Triple("ZZZZZZZ", false, true)
     ))
 
     workforceAllocationsToDelius.setupTeam1CaseDetails()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetUnallocatedCasesByTeamTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetUnallocatedCasesByTeamTests.kt
@@ -16,17 +16,19 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
 
   private fun testUnallocatedCasesByTeamSuccessWithAllDataSetupAndAssertions(
     probationEstateTeamsAndRegionsApiIsWorking: Boolean,
-    vararg extraCaseDetailsIntegrations: CaseDetailsIntegration
+    vararg extraCaseDetailsIntegrations: CaseDetailsIntegration,
   ) {
-    workforceAllocationsToDelius.userHasAccessToAllCases(listOf(
-      Triple("J678910", false, false),
-      Triple("J680648", false, false),
-      Triple("X4565764", false, false),
-      Triple("J680660", false, false),
-      Triple("X6666222", false, false),
-      Triple("XXXXXXX", true, false),
-      Triple("ZZZZZZZ", false, true)
-    ))
+    workforceAllocationsToDelius.userHasAccessToAllCases(
+      listOf(
+        Triple("J678910", false, false),
+        Triple("J680648", false, false),
+        Triple("X4565764", false, false),
+        Triple("J680660", false, false),
+        Triple("X6666222", false, false),
+        Triple("XXXXXXX", true, false),
+        Triple("ZZZZZZZ", false, true),
+      ),
+    )
     insertCases()
     val initialAppointment = LocalDate.of(2022, 10, 11)
     val firstSentenceDate = LocalDate.of(2022, 11, 5)
@@ -179,15 +181,17 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
 
   @Test
   fun `return error when error on Delius API call`() {
-    workforceAllocationsToDelius.userHasAccessToAllCases(listOf(
-      Triple("J678910", false, false),
-      Triple("J680648", false, false),
-      Triple("X4565764", false, false),
-      Triple("J680660", false, false),
-      Triple("X6666222", false, false),
-      Triple("XXXXXXX", true, false),
-      Triple("ZZZZZZZ", false, true)
-    ))
+    workforceAllocationsToDelius.userHasAccessToAllCases(
+      listOf(
+        Triple("J678910", false, false),
+        Triple("J680648", false, false),
+        Triple("X4565764", false, false),
+        Triple("J680660", false, false),
+        Triple("X6666222", false, false),
+        Triple("XXXXXXX", true, false),
+        Triple("ZZZZZZZ", false, true),
+      ),
+    )
     insertCases()
 
     workforceAllocationsToDelius.errorDeliusCaseDetailsResponse()
@@ -240,15 +244,17 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
 
   @Test
   fun `must return sentence length`() {
-    workforceAllocationsToDelius.userHasAccessToAllCases(listOf(
-      Triple("J678910", false, false),
-      Triple("J680648", false, false),
-      Triple("X4565764", false, false),
-      Triple("J680660", false, false),
-      Triple("X6666222", false, false),
-      Triple("XXXXXXX", true, false),
-      Triple("ZZZZZZZ", false, true)
-    ))
+    workforceAllocationsToDelius.userHasAccessToAllCases(
+      listOf(
+        Triple("J678910", false, false),
+        Triple("J680648", false, false),
+        Triple("X4565764", false, false),
+        Triple("J680660", false, false),
+        Triple("X6666222", false, false),
+        Triple("XXXXXXX", true, false),
+        Triple("ZZZZZZZ", false, true),
+      ),
+    )
 
     workforceAllocationsToDelius.setupTeam1CaseDetails()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetUnallocatedCasesByTeamTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/unallocatedcases/GetUnallocatedCasesByTeamTests.kt
@@ -13,12 +13,13 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
   private fun testUnallocatedCasesByTeamSuccessWithAllDataSetupAndAssertions(
     probationEstateTeamsAndRegionsApiIsWorking: Boolean,
   ) {
-    workforceAllocationsToDelius.userHasAccess("J678910")
-    workforceAllocationsToDelius.userHasAccess("J680648")
-    workforceAllocationsToDelius.userHasAccess("X4565764")
-    workforceAllocationsToDelius.userHasAccess("J680660")
-    workforceAllocationsToDelius.userHasAccess("X6666222")
-
+    workforceAllocationsToDelius.userHasAccessToAllCases(listOf(
+      Triple("J678910", false, false),
+      Triple("J680648", false, false),
+      Triple("X4565764", false, false),
+      Triple("J680660", false, false),
+      Triple("X6666222", false, false)
+    ))
     insertCases()
     val initialAppointment = LocalDate.of(2022, 10, 11)
     val firstSentenceDate = LocalDate.of(2022, 11, 5)
@@ -145,12 +146,13 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
 
   @Test
   fun `return error when error on Delius API call`() {
-    workforceAllocationsToDelius.userHasAccess("J678910")
-    workforceAllocationsToDelius.userHasAccess("J680648")
-    workforceAllocationsToDelius.userHasAccess("X4565764")
-    workforceAllocationsToDelius.userHasAccess("J680660")
-    workforceAllocationsToDelius.userHasAccess("X6666222")
-
+    workforceAllocationsToDelius.userHasAccessToAllCases(listOf(
+      Triple("J678910", false, false),
+      Triple("J680648", false, false),
+      Triple("X4565764", false, false),
+      Triple("J680660", false, false),
+      Triple("X6666222", false, false)
+    ))
     insertCases()
 
     workforceAllocationsToDelius.errorDeliusCaseDetailsResponse()
@@ -203,11 +205,13 @@ class GetUnallocatedCasesByTeamTests : IntegrationTestBase() {
 
   @Test
   fun `must return sentence length`() {
-    workforceAllocationsToDelius.userHasAccess("J678910")
-    workforceAllocationsToDelius.userHasAccess("J680648")
-    workforceAllocationsToDelius.userHasAccess("X4565764")
-    workforceAllocationsToDelius.userHasAccess("J680660")
-    workforceAllocationsToDelius.userHasAccess("X6666222")
+    workforceAllocationsToDelius.userHasAccessToAllCases(listOf(
+      Triple("J678910", false, false),
+      Triple("J680648", false, false),
+      Triple("X4565764", false, false),
+      Triple("J680660", false, false),
+      Triple("X6666222", false, false)
+    ))
 
     workforceAllocationsToDelius.setupTeam1CaseDetails()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetUnallocatedCaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetUnallocatedCaseServiceTest.kt
@@ -60,7 +60,6 @@ internal class GetUnallocatedCaseServiceTest {
     )
 
     every { mockRepo.findByTeamCode("TM1") } returns listOf(unallocatedCaseEntity)
-    every { mockRepo.existsByCrnAndConvictionNumber(crn, 1) } returns true
     coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getUserAccess(crn) } returns
       DeliusCaseAccess(crn, userRestricted = true, true)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetUnallocatedCaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetUnallocatedCaseServiceTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.DeliusCaseAccess
+import uk.gov.justice.digital.hmpps.hmppsallocations.client.DeliusUserAccess
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.WorkforceAllocationsToDeliusApiClient
 import uk.gov.justice.digital.hmpps.hmppsallocations.jpa.entity.UnallocatedCaseEntity
 import uk.gov.justice.digital.hmpps.hmppsallocations.jpa.repository.UnallocatedCasesRepository
@@ -36,9 +37,10 @@ internal class GetUnallocatedCaseServiceTest {
       )
       every { mockRepo.findByTeamCode("TM1") } returns listOf(unallocatedCaseEntity)
       every { mockRepo.existsById(id) } returns false
-      coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getUserAccess(crn) } returns
-        DeliusCaseAccess(crn, userRestricted = false, false)
-
+      coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getUserAccess(listOf(crn)) } returns
+        DeliusUserAccess(
+          access = listOf(DeliusCaseAccess(crn, userRestricted = false, false))
+        )
       coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getDeliusCaseDetailsCases(listOf(unallocatedCaseEntity)) } returns emptyFlow()
       val cases = GetUnallocatedCaseService(mockRepo, mockOutOfAreaTransferService, mockk(), mockWorkforceAllocationsToDeliusApiClientClient)
         .getAllByTeam("TM1").toList()
@@ -60,8 +62,10 @@ internal class GetUnallocatedCaseServiceTest {
     )
 
     every { mockRepo.findByTeamCode("TM1") } returns listOf(unallocatedCaseEntity)
-    coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getUserAccess(crn) } returns
-      DeliusCaseAccess(crn, userRestricted = true, true)
+    coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getUserAccess(listOf(crn)) } returns
+      DeliusUserAccess(
+        access = listOf(DeliusCaseAccess(crn, userRestricted = true, true))
+      )
 
     coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getDeliusCaseDetailsCases(emptyList()) } returns emptyFlow()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetUnallocatedCaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetUnallocatedCaseServiceTest.kt
@@ -39,7 +39,7 @@ internal class GetUnallocatedCaseServiceTest {
       every { mockRepo.existsById(id) } returns false
       coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getUserAccess(listOf(crn)) } returns
         DeliusUserAccess(
-          access = listOf(DeliusCaseAccess(crn, userRestricted = false, false))
+          access = listOf(DeliusCaseAccess(crn, userRestricted = false, false)),
         )
       coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getDeliusCaseDetailsCases(listOf(unallocatedCaseEntity)) } returns emptyFlow()
       val cases = GetUnallocatedCaseService(mockRepo, mockOutOfAreaTransferService, mockk(), mockWorkforceAllocationsToDeliusApiClientClient)
@@ -64,7 +64,7 @@ internal class GetUnallocatedCaseServiceTest {
     every { mockRepo.findByTeamCode("TM1") } returns listOf(unallocatedCaseEntity)
     coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getUserAccess(listOf(crn)) } returns
       DeliusUserAccess(
-        access = listOf(DeliusCaseAccess(crn, userRestricted = true, true))
+        access = listOf(DeliusCaseAccess(crn, userRestricted = true, true)),
       )
 
     coEvery { mockWorkforceAllocationsToDeliusApiClientClient.getDeliusCaseDetailsCases(emptyList()) } returns emptyFlow()


### PR DESCRIPTION
This PR includes:
- only hitting Delius API once to get LAO status (userRestricted / userExcluded) instead of 1 hit per case
- no longer going back to the DB to check the records we get back from Delius are valid (1 DB hit per record). Instead, using the list of unallocated cases we previously got back from DB to check the validity of what Delius gave us back (and filtering accordingly). This achieves the same thing with 0 DB hits.
- boost test coverage for everything