### PR TITLE
WFP-2274 - surface handoverDate in unallocated-cases API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/WorkforceAllocationsToDeliusApiClient.kt
@@ -165,6 +165,7 @@ data class DeliusCaseDetail(
   val probationStatus: ProbationStatus,
   val communityPersonManager: CommunityPersonManager?,
   val type: String,
+  val handoverDate: LocalDate?,
 )
 
 data class Event(val number: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/domain/UnallocatedCase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/domain/UnallocatedCase.kt
@@ -18,6 +18,8 @@ data class UnallocatedCase @JsonCreator constructor(
   @Schema(description = "Sentence Date", example = "2020-01-16")
   @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
   val sentenceDate: LocalDate,
+  @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+  val handoverDate: LocalDate?,
   @JsonInclude(JsonInclude.Include.NON_NULL)
   val initialAppointment: InitialAppointmentDetails?,
   @Schema(description = "Probation Status", example = "Currently managed")
@@ -54,6 +56,7 @@ data class UnallocatedCase @JsonCreator constructor(
         sentenceLength = deliusCaseDetail.sentence.length,
         convictionNumber = case.convictionNumber,
         outOfAreaTransfer = outOfAreaTransfer,
+        handoverDate = deliusCaseDetail.handoverDate,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/IntegrationTestBase.kt
@@ -139,6 +139,10 @@ abstract class IntegrationTestBase {
     )
   }
 
+  fun insertCase(unallocatedCase: UnallocatedCaseEntity) {
+    repository.save(unallocatedCase)
+  }
+
   @BeforeEach
   fun `clear queues and database`() {
     repository.deleteAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/domain/CaseDetailsIntegration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/domain/CaseDetailsIntegration.kt
@@ -10,4 +10,5 @@ data class CaseDetailsIntegration(
   val probationStatus: String,
   val probationStatusDescription: String,
   val communityPersonManager: CommunityPersonManager?,
+  val handoverDate: String?,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/mockserver/WorkforceAllocationsToDeliusMockServer.kt
@@ -62,6 +62,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
     probationStatus = "CURRENTLY_MANAGED",
     probationStatusDescription = "Currently managed",
     communityPersonManager = CommunityPersonManager(Name("Beverley", null, "Smith"), "SPO", "TEAM1"),
+    handoverDate = null,
   )
 
   private val currentMangedByTeam2CaseDetails = CaseDetailsIntegration(
@@ -71,6 +72,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
     probationStatus = "CURRENTLY_MANAGED",
     probationStatusDescription = "Currently managed",
     communityPersonManager = CommunityPersonManager(Name("Joe", null, "Bloggs"), "SPO", "TEAM2"),
+    handoverDate = null,
   )
 
   companion object {
@@ -129,6 +131,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
         probationStatus = "PREVIOUSLY_MANAGED",
         probationStatusDescription = "Previously managed",
         communityPersonManager = CommunityPersonManager(Name("Janie", null, "Jones"), "PO", "TEAM1"),
+        handoverDate = null,
       ),
       CaseDetailsIntegration(
         crn = "X4565764",
@@ -137,6 +140,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
         probationStatus = "NEW_TO_PROBATION",
         probationStatusDescription = "New to probation",
         communityPersonManager = CommunityPersonManager(Name("Beverley", null, "Smith"), "SPO", "TEAM1"),
+        handoverDate = null,
       ),
       CaseDetailsIntegration(
         crn = "J680660",
@@ -145,6 +149,7 @@ class WorkforceAllocationsToDeliusMockServer : ClientAndServer(MOCKSERVER_PORT) 
         probationStatus = "PREVIOUSLY_MANAGED",
         probationStatusDescription = "Previously managed",
         communityPersonManager = null,
+        handoverDate = null,
       ),
       *extraCaseDetailsIntegrations,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/responses/workforceallocationstodelius/FullDeliusCaseDetailsResponse.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/integration/responses/workforceallocationstodelius/FullDeliusCaseDetailsResponse.kt
@@ -44,9 +44,16 @@ private fun deliusCaseDetail(caseDetailsIntegration: CaseDetailsIntegration) = "
          "description": "${caseDetailsIntegration.probationStatusDescription}"
       }
   """ +
+  handoverDate(caseDetailsIntegration.handoverDate) +
   initialAppointment(caseDetailsIntegration.initialAppointment) +
   communityPersonManager(caseDetailsIntegration.communityPersonManager) +
   "}".trimIndent()
+
+private fun handoverDate(handoverDate: String?) = if (handoverDate != null) {
+  ""","handoverDate": "$handoverDate" """
+} else {
+  ""","handoverDate": null """
+}
 
 private fun initialAppointment(initialAppointment: InitialAppointment?): String {
   return initialAppointment?.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/OutOfAreaTransferServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/OutOfAreaTransferServiceTest.kt
@@ -114,6 +114,7 @@ internal class OutOfAreaTransferServiceTest {
         teamCode = communityPersonManagerTeamCode,
       ),
       type = "",
+      handoverDate = mockk(),
     )
   }
 


### PR DESCRIPTION
PR to surface `handoverDate` in unallocated-cases API:

<img width="1728" alt="Screenshot 2024-01-18 at 15 57 16" src="https://github.com/ministryofjustice/hmpps-allocations/assets/148795810/184ecd02-6426-4122-85ea-c339eb989708">
