### PR TITLE
revert renovate-generic-service merge

### DIFF
--- a/helm_deploy/hmpps-allocations/Chart.yaml
+++ b/helm_deploy/hmpps-allocations/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-allocations
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: "3.1"
+    version: "2.9"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.4.0


### PR DESCRIPTION
merging previous branch (renovate-generic-service-3.x) has caused deploy to fail. 
(test and build pass but fails to deploy)
So reverting