### PR TITLE
Wfp 2489 add queue name to logs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/CalculationEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/CalculationEventListener.kt
@@ -10,11 +10,13 @@ import kotlinx.coroutines.future.future
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsallocations.service.TierCalculationService
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Component
 class CalculationEventListener(
   private val calculationTierService: TierCalculationService,
   private val objectMapper: ObjectMapper,
+  private val hmppsQueueService: HmppsQueueService,
 ) {
 
   @SqsListener("tiercalculationqueue", factory = "hmppsQueueContainerFactoryProxy")
@@ -27,7 +29,8 @@ class CalculationEventListener(
 
   private fun readMessage(wrapper: String?): CalculationEventData {
     val message = objectMapper.readValue(wrapper, QueueMessage::class.java)
-    log.info("Received message from SQS queue tiercalculationqueue with messageId:{}", message.messageId)
+    val queueId = hmppsQueueService.findByQueueName("tiercalculationqueue")?.id
+    log.info("Received message from SQS queue {} with messageId:{}", queueId, message.messageId)
     return objectMapper.readValue(message.message, CalculationEventData::class.java)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/CalculationEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/CalculationEventListener.kt
@@ -10,13 +10,11 @@ import kotlinx.coroutines.future.future
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsallocations.service.TierCalculationService
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Component
 class CalculationEventListener(
   private val calculationTierService: TierCalculationService,
   private val objectMapper: ObjectMapper,
-  private val hmppsQueueService: HmppsQueueService,
 ) {
 
   @SqsListener("tiercalculationqueue", factory = "hmppsQueueContainerFactoryProxy")
@@ -29,8 +27,7 @@ class CalculationEventListener(
 
   private fun readMessage(wrapper: String?): CalculationEventData {
     val message = objectMapper.readValue(wrapper, QueueMessage::class.java)
-    val queueName = hmppsQueueService.findByQueueName("tiercalculationqueue")?.queueName
-    log.info("Received message from SQS queue {} with messageId:{}", queueName, message.messageId)
+    log.info("Received message from SQS queue tiercalculationqueue with messageId:{}", message.messageId)
     return objectMapper.readValue(message.message, CalculationEventData::class.java)
   }
 
@@ -51,6 +48,4 @@ class CalculationEventListener(
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   data class QueueMessage(@JsonProperty("Message") val message: String, @JsonProperty("MessageId") val messageId: String?)
-
-  // data class Message(@JsonProperty("Message") val message: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/OffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/OffenderEventListener.kt
@@ -11,13 +11,11 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.ForbiddenOffenderError
 import uk.gov.justice.digital.hmpps.hmppsallocations.service.UpsertUnallocatedCaseService
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Component
 class OffenderEventListener(
   private val objectMapper: ObjectMapper,
   private val upsertUnallocatedCaseService: UpsertUnallocatedCaseService,
-  private val hmppsQueueService: HmppsQueueService,
 ) {
 
   @SqsListener("hmppsoffenderqueue", factory = "hmppsQueueContainerFactoryProxy")
@@ -34,8 +32,7 @@ class OffenderEventListener(
 
   private fun getCrn(rawMessage: String): String {
     val message = objectMapper.readValue(rawMessage, QueueMessage::class.java)
-    val queueName = hmppsQueueService.findByQueueName("hmppsoffenderqueue")?.queueName
-    log.info("Received message from SQS queue {} with messageId: {}", queueName, message.messageId)
+    log.info("Received message from SQS queue hmppsoffenderqueue with messageId: {}", message.messageId)
     return objectMapper.readValue(message.message, HmppsOffenderEvent::class.java).crn
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/OffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/OffenderEventListener.kt
@@ -20,7 +20,9 @@ class OffenderEventListener(
 
   @SqsListener("hmppsoffenderqueue", factory = "hmppsQueueContainerFactoryProxy")
   fun processMessage(rawMessage: String) {
+    log.debug("processing message")
     val crn = getCrn(rawMessage)
+    log.debug("Retrieved message CRN: $crn")
     CoroutineScope(Dispatchers.Default).future {
       try {
         upsertUnallocatedCaseService.upsertUnallocatedCase(crn)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/OffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/OffenderEventListener.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsallocations.listener
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.awspring.cloud.sqs.annotation.SqsListener
@@ -10,18 +11,18 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.ForbiddenOffenderError
 import uk.gov.justice.digital.hmpps.hmppsallocations.service.UpsertUnallocatedCaseService
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Component
 class OffenderEventListener(
   private val objectMapper: ObjectMapper,
   private val upsertUnallocatedCaseService: UpsertUnallocatedCaseService,
+  private val hmppsQueueService: HmppsQueueService,
 ) {
 
   @SqsListener("hmppsoffenderqueue", factory = "hmppsQueueContainerFactoryProxy")
   fun processMessage(rawMessage: String) {
-    log.debug("processing message")
     val crn = getCrn(rawMessage)
-    log.debug("Retrieved message CRN: $crn")
     CoroutineScope(Dispatchers.Default).future {
       try {
         upsertUnallocatedCaseService.upsertUnallocatedCase(crn)
@@ -32,8 +33,10 @@ class OffenderEventListener(
   }
 
   private fun getCrn(rawMessage: String): String {
-    val (message) = objectMapper.readValue(rawMessage, SQSMessage::class.java)
-    return objectMapper.readValue(message, HmppsOffenderEvent::class.java).crn
+    val message = objectMapper.readValue(rawMessage, QueueMessage::class.java)
+    val queueName = hmppsQueueService.findByQueueName("hmppsoffenderqueue")?.queueName
+    log.info("Received message from SQS queue {} with messageId: {}", queueName, message.messageId)
+    return objectMapper.readValue(message.message, HmppsOffenderEvent::class.java).crn
   }
 
   companion object {
@@ -43,6 +46,12 @@ class OffenderEventListener(
 
 data class HmppsOffenderEvent(
   val crn: String,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class QueueMessage(
+  @JsonProperty("Message") val message: String,
+  @JsonProperty("MessageId") val messageId: String?,
 )
 
 data class SQSMessage(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/OffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/listener/OffenderEventListener.kt
@@ -11,11 +11,13 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.ForbiddenOffenderError
 import uk.gov.justice.digital.hmpps.hmppsallocations.service.UpsertUnallocatedCaseService
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Component
 class OffenderEventListener(
   private val objectMapper: ObjectMapper,
   private val upsertUnallocatedCaseService: UpsertUnallocatedCaseService,
+  private val hmppsQueueService: HmppsQueueService,
 ) {
 
   @SqsListener("hmppsoffenderqueue", factory = "hmppsQueueContainerFactoryProxy")
@@ -34,7 +36,8 @@ class OffenderEventListener(
 
   private fun getCrn(rawMessage: String): String {
     val message = objectMapper.readValue(rawMessage, QueueMessage::class.java)
-    log.info("Received message from SQS queue hmppsoffenderqueue with messageId: {}", message.messageId)
+    val queueId = hmppsQueueService.findByQueueName("hmppsoffenderqueue")?.id
+    log.info("Received message from SQS queue {} with messageId: {}", queueId, message.messageId)
     return objectMapper.readValue(message.message, HmppsOffenderEvent::class.java).crn
   }
 


### PR DESCRIPTION
Adding in the AWS Queue ID instead of the parameter name