### PR TITLE
WFP-2608 Deploy our epic branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,11 @@ jobs:
           name: Wait for localstack to be ready
           command: curl -4 --connect-timeout 30 --retry-connrefused --retry 20 --retry-delay 5 http://localhost:4566
       - run:
-          command: ./gradlew check
-      - when:
-          condition:
-            equal: [ main, << pipeline.git.branch >> ]
+          command:
+            BRANCH_NAME=<< pipeline.git.branch >>
+            PATTERN="^(main|epic.*)$"
+            if [[$BRANCH_NAME =~ $PATTERN ]]; then        
+              ./gradlew check
           steps:
             - slack/notify:
                 event: fail
@@ -63,7 +64,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - \b(main|epic-\w+)\b
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"
@@ -73,7 +74,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - \b(main|epic-\w+)\b
           requires:
             - validate
             - build_docker
@@ -89,7 +90,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - \b(main|epic-\w+)\b
           requires:
             - validate
             - build_docker
@@ -118,7 +119,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - \b(main|epic-\w+)\b
     jobs:
       - hmpps/gradle_owasp_dependency_check:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
@@ -141,7 +142,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - \b(main|epic-\w+)\b
     jobs:
       - hmpps/veracode_policy_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
             PATTERN="^(main|epic.*)$"
             if [[$BRANCH_NAME =~ $PATTERN ]]; then        
               ./gradlew check
+            fi
           steps:
             - slack/notify:
                 event: fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,11 @@ jobs:
           command: curl -4 --connect-timeout 30 --retry-connrefused --retry 20 --retry-delay 5 http://localhost:4566
       - run:
           command:
-            BRANCH_NAME=<< pipeline.git.branch >>
-            PATTERN="^(main|epic.*)$"
-            if [[ $BRANCH_NAME =~ $PATTERN ]]; then        
-              ./gradlew check
-            fi
+            ./gradlew check
+          filters:
+            branches:
+              only:
+                - \b(main|epic-\w+)\b
           steps:
             - slack/notify:
                 event: fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command:
             BRANCH_NAME=<< pipeline.git.branch >>
             PATTERN="^(main|epic.*)$"
-            if [[$BRANCH_NAME =~ $PATTERN ]]; then        
+            if [[ $BRANCH_NAME =~ $PATTERN ]]; then        
               ./gradlew check
             fi
           steps:


### PR DESCRIPTION
This will enable us to deploy (to lower environments) a branch prefixed with the word 'epic' ... eg. 'epic-for-contact-work' or 'epic-for-probation-reset' . It will also allow the branch 'main' through as usual (on to be deployed into production)

