### PR TITLE
change jre to jdk to add heat dump tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-jammy AS builder
+FROM eclipse-temurin:21-jdk-jammy AS builder
 
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
@@ -11,7 +11,7 @@ RUN ./gradlew assemble -Dorg.gradle.daemon=false
 RUN apt-get update && apt-get install -y curl
 RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem  > root.crt
 
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:21-jdk-jammy
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ARG BUILD_NUMBER


### PR DESCRIPTION
The project is currently using the Java Runtime Environment (JRE) but in order to use JVM monitoring tools such as heap dump output we can use the Java Development Kit (JDK). This PR updates the project to use the JDK so that we can use these tools to investigate a potential memory leak