### PR TITLE
Wfp 3616 reallocations crn bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/dto/DeliusAllocatedCaseView.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/client/dto/DeliusAllocatedCaseView.kt
@@ -38,7 +38,7 @@ data class AllocatedActiveEvent @JsonCreator constructor(
 
 data class AllocatedEventRequirement @JsonCreator constructor(
   val mainCategory: String,
-  val subCategory: String,
+  val subCategory: String?,
   val length: String,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetAllocatedCaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetAllocatedCaseServiceTest.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.aot.hint.TypeReference.listOf
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.AssessRisksNeedsApiClient
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.HmppsTierApiClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetAllocatedCaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsallocations/service/GetAllocatedCaseServiceTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.aot.hint.TypeReference.listOf
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.AssessRisksNeedsApiClient
 import uk.gov.justice.digital.hmpps.hmppsallocations.client.HmppsTierApiClient
@@ -81,7 +82,7 @@ class GetAllocatedCaseServiceTest {
             "12 months",
           ),
           listOf(AllocatedEventOffences("Burglary", "Theft", true)),
-          listOf(AllocatedEventRequirement("Curfew", "Must comply with curfew", "6 months")),
+          listOf(AllocatedEventRequirement("Curfew", null, "6 months")),
         ),
       ),
     )


### PR DESCRIPTION
We’ve had a recent production issue when calling the integrations endpoint `/reallocation/{crn}/case-view` and have hit an issue when deserialising the response. 
For some records, the `requirements[].subCategory` field is either missing or null in the response. 
In the DTO we're expecting `requirements[].subCategory` to always have a value, so this is causing the app to crash. I checked the logs in the namespace and could see this was causing the issue. So this PR makes subCategory nullable and should fix the bug. This is just in reallocations.
In allocations subCategory is already nullable and on the FE it's conditional to display if the data is there, so must just have been missed in reallocations.