### PR TITLE
Remove local NVD cache configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,11 +27,6 @@ configurations.matching { it.name == "detekt" }.all {
   }
 }
 
-dependencyCheck {
-  suppressionFiles.add("suppressions.xml")
-  nvd.datafeedUrl = "file:///opt/vulnz/cache"
-}
-
 allOpen {
   annotations("jakarta.persistence.Entity")
 }


### PR DESCRIPTION
Configuration change required to support the move to Github Pages for the NVD Cache. As per [this conversation](https://mojdt.slack.com/archives/C06MWP0UKDE/p1784300758956369) - the local configuration overrides the OWASP workflow parameter